### PR TITLE
Added dependency on grunt-lib-contrib

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,11 @@
   "scripts": {
     "test": "grunt test"
   },
+  "dependencies": {
+    "grunt-lib-contrib": "~0.4.0"
+  },
   "devDependencies": {
-    "grunt": "~0.3.17"
+    "grunt": "~0.4.0"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
I needed this for the task to run after installing 0.4.0 alongside grunt 0.4.0a
