### PR TITLE
read env properties from .env files

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+dotEnvFileData=bar
+dotEnvFileOption=baz

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,7 +44,14 @@ module.exports = function(grunt) {
     delete process.env.localOption;
   });
 
+  grunt.registerTask('testDotEnv', function(grunt){
+    assert.equal(process.env.dotEnvFileData, 'bar', 'dotEnvFileData should be set');
+    assert.equal(process.env.dotEnvFileOption, 'baz', 'dotEnvFileOption should be set');
+    delete process.env.dotEnvFileData;
+    delete process.env.dotEnvFileOption;
+  });
+
   // Default task.
-  grunt.registerTask('default', ['jshint','env:testData', 'testData', 'env:testOptions', 'testOptions']);
+  grunt.registerTask('default', ['jshint','env:testData', 'testData', 'env:testOptions', 'testOptions', 'testDotEnv']);
 
 };

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "gruntplugin",
     "env",
     "config"
-  ]
+  ],
+  "dependencies": {
+    "ini": "~1.1.0"
+  }
 }

--- a/tasks/env.js
+++ b/tasks/env.js
@@ -9,7 +9,10 @@
 "use strict";
 
 module.exports = function (grunt) {
+  var ini = require('ini');
+
   grunt.registerMultiTask('env', 'Specify an ENV configuration for future tasks in the chain', function() {
     grunt.util._.extend(process.env, this.options(), this.data);
+    grunt.util._.extend(process.env, ini.parse(grunt.file.read('.env')));
   });
 };


### PR DESCRIPTION
if .env file is exist at base path of app, read properties from .env file. i was needed this feature to make compatible with foreman of heroku [1](https://devcenter.heroku.com/articles/config-vars#using-foreman)
