### PR TITLE
Allow global env files to be specified in options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,8 @@ module.exports = function(grunt) {
   grunt.initConfig({
     env : {
       options: {
-        globalOption : 'foo'
+        globalOption : 'foo',
+        src: '.env-global'
       },
       testData : {
         data : 'bar'
@@ -54,6 +55,11 @@ module.exports = function(grunt) {
   grunt.registerTask('writeDotEnv', function(){
     grunt.file.write('.env', "dotEnvFileData=bar\ndotEnvFileOption=baz\n");
     grunt.file.write('.env.json', '{"jsonValue" : "foo"}');
+
+  });
+
+  grunt.registerTask('writeDotEnvGlobal', function(){
+    grunt.file.write('.env-global', "dotEnvGlobalFileOption=pop\n");
   });
 
   grunt.registerTask('testDotEnv', function(){
@@ -61,15 +67,18 @@ module.exports = function(grunt) {
     assert.equal(process.env.jsonValue, 'foo', 'value from json env file should be set');
     assert.equal(process.env.dotEnvFileData, 'bar', 'dotEnvFileData should be set');
     assert.equal(process.env.dotEnvFileOption, 'baz', 'dotEnvFileOption should be set');
+    assert.equal(process.env.dotEnvGlobalFileOption, 'pop', 'dotEnvGlobalFileOption should be set')
     delete process.env.jsonValue;
     delete process.env.dotEnvFileData;
     delete process.env.dotEnvFileOption;
+    delete process.env.dotEnvGlobalFileOption;
   });
 
   // Default task.
   grunt.registerTask('default', [
     'clean',
     'jshint',
+    'writeDotEnvGlobal',
     'env:testData',
     'testData',
     'env:testOptions',


### PR DESCRIPTION
A src property can be added to the options object. This can be a single file or a list of files.

This makes it a lot easier to have global config set in one place and any customisations to be made in the environments as needed.

The order of env configuration is now:
- options (without src)
- options.src
- specific enviroment