### PR TITLE
Yaml support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
         }
       },
       testDotEnv : {
-        src : ['.env', '.env.json']
+        src : ['.env', '.env.ini', '.env.json', '.env.yaml']
       },
       testEnvdir: {
         src : ['.envdir/*'],
@@ -122,20 +122,35 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('writeDotEnv', function(){
+<<<<<<< HEAD
     grunt.file.write('.env', "dotEnvFileData=bar\ndotEnvFileOption=baz");
     grunt.file.write('.env.json', '{"jsonValue" : "foo","push" : {"PATHLIKE":"jsonPath"}}');
+=======
+    grunt.file.write('.env', "dotEnvFileData=bar\ndotEnvFileOption=baz\n");
+    grunt.file.write('.env.ini', "dotEnvIniFileData=bar.ini\ndotEnvIniFileOption=baz.ini\n");
+    grunt.file.write('.env.json', '{"jsonValue" : "foo"}');
+    grunt.file.write('.env.yaml', 'yamlValue: foo');
+>>>>>>> Added support for YAML file
   });
 
   grunt.registerTask('testDotEnv', function(){
     assert(!process.env.src, 'Should not include src');
     assert.equal(process.env.jsonValue, 'foo', 'value from json env file should be set');
+<<<<<<< HEAD
     assert.equal(process.env.PATHLIKE, 'jsonPath', 'should process directives in json');
     assert.equal(process.env.globalOption, 'foo', 'should still get global options');
+=======
+    assert.equal(process.env.yamlValue, 'foo', 'value from yaml env file should be set');
+>>>>>>> Added support for YAML file
     assert.equal(process.env.dotEnvFileData, 'bar', 'dotEnvFileData should be set');
     assert.equal(process.env.dotEnvFileOption, 'baz', 'dotEnvFileOption should be set');
+    assert.equal(process.env.dotEnvIniFileData, 'bar.ini', 'dotEnvIniFileData should be set');
+    assert.equal(process.env.dotEnvIniFileOption, 'baz.ini', 'dotEnvIniFileOption should be set');
     delete process.env.jsonValue;
+    delete process.env.yamlValue;
     delete process.env.dotEnvFileData;
     delete process.env.dotEnvFileOption;
+<<<<<<< HEAD
     delete process.env.PATHLIKE;
     delete process.env.globalOption;
   });
@@ -154,6 +169,10 @@ module.exports = function(grunt) {
     assert(!process.env.FOO, 'Should not include subdirectories');
     delete process.env.ENVDIR;
     delete process.env.BAR;
+=======
+    delete process.env.dotEnvIniFileData;
+    delete process.env.dotEnvIniFileOption;
+>>>>>>> Added support for YAML file
   });
 
   // Default task.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,6 +64,9 @@ module.exports = function(grunt) {
           return process.env.DATA_FROM_FUNCTION || '123';
         },
         A_STRING: 'string'
+      },
+      testDotUppercaseExtensionEnv: {
+        src: ['.env.YAML']
       }
     },
     clean : {
@@ -122,37 +125,30 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('writeDotEnv', function(){
-<<<<<<< HEAD
     grunt.file.write('.env', "dotEnvFileData=bar\ndotEnvFileOption=baz");
     grunt.file.write('.env.json', '{"jsonValue" : "foo","push" : {"PATHLIKE":"jsonPath"}}');
-=======
     grunt.file.write('.env', "dotEnvFileData=bar\ndotEnvFileOption=baz\n");
     grunt.file.write('.env.ini', "dotEnvIniFileData=bar.ini\ndotEnvIniFileOption=baz.ini\n");
     grunt.file.write('.env.json', '{"jsonValue" : "foo"}');
     grunt.file.write('.env.yaml', 'yamlValue: foo');
->>>>>>> Added support for YAML file
   });
 
   grunt.registerTask('testDotEnv', function(){
     assert(!process.env.src, 'Should not include src');
     assert.equal(process.env.jsonValue, 'foo', 'value from json env file should be set');
-<<<<<<< HEAD
     assert.equal(process.env.PATHLIKE, 'jsonPath', 'should process directives in json');
     assert.equal(process.env.globalOption, 'foo', 'should still get global options');
-=======
     assert.equal(process.env.yamlValue, 'foo', 'value from yaml env file should be set');
->>>>>>> Added support for YAML file
     assert.equal(process.env.dotEnvFileData, 'bar', 'dotEnvFileData should be set');
     assert.equal(process.env.dotEnvFileOption, 'baz', 'dotEnvFileOption should be set');
     assert.equal(process.env.dotEnvIniFileData, 'bar.ini', 'dotEnvIniFileData should be set');
     assert.equal(process.env.dotEnvIniFileOption, 'baz.ini', 'dotEnvIniFileOption should be set');
     delete process.env.jsonValue;
+    delete process.env.PATHLIKE;
+    delete process.env.globalOption;
     delete process.env.yamlValue;
     delete process.env.dotEnvFileData;
     delete process.env.dotEnvFileOption;
-<<<<<<< HEAD
-    delete process.env.PATHLIKE;
-    delete process.env.globalOption;
   });
 
   grunt.registerTask("writeEnvdir", function(){
@@ -169,10 +165,18 @@ module.exports = function(grunt) {
     assert(!process.env.FOO, 'Should not include subdirectories');
     delete process.env.ENVDIR;
     delete process.env.BAR;
-=======
     delete process.env.dotEnvIniFileData;
     delete process.env.dotEnvIniFileOption;
->>>>>>> Added support for YAML file
+  });
+
+  grunt.registerTask('writeDotUppercaseEnv', function(){
+    grunt.file.write('.env.YAML', 'anotherYamlValue: bar');
+  });
+
+  grunt.registerTask('testDotUppercaseExtensionEnv', function(){
+    assert(!process.env.src, 'Should not include src');
+    assert.equal(process.env.anotherYamlValue, 'bar', 'value from YAML env file should be set');
+    delete process.env.anotherYamlValue;
   });
 
   // Default task.
@@ -196,4 +200,9 @@ module.exports = function(grunt) {
     'clean'
   ]);
 
+  grunt.registerTask('uppercaseExtension', [
+    'writeDotUppercaseEnv',
+    'env:testDotUppercaseExtensionEnv',
+    'testDotUppercaseExtensionEnv'
+  ]);
 };

--- a/README.md
+++ b/README.md
@@ -51,13 +51,16 @@ grunt.loadNpmTasks('grunt-env');
 ```
 ## Using external files
 
-You can specify environment values in INI or JSON style and load them via the src option.
+You can specify environment values in INI, JSON or YAML style and load them via the src option.
 
 ```js
   env : {
     dev : {
       src : "dev.json"
     },
+    prod: {
+      src: "settings.yaml"
+    }
     heroku : {
       src : ".env"
     }

--- a/tasks/env.js
+++ b/tasks/env.js
@@ -14,6 +14,22 @@ var _ = require('lodash'),
 
 module.exports = function (grunt) {
 
+  var readJson = function (file) {
+    try {
+      return grunt.file.readJSON(file);
+    } catch(e) {
+      return;
+    }
+  };
+
+  var readIni = function (file) {
+    try {
+      return ini.parse(grunt.file.read(file));
+    } catch(e) {
+      return;
+    }
+  };
+
   grunt.registerMultiTask('env', 'Specify an ENV configuration for future tasks in the chain', function() {
 
     var data = grunt.util._.clone(this.data);
@@ -32,9 +48,8 @@ module.exports = function (grunt) {
         processDirectives(d);
       } else {
         this.files[0].src.forEach(function(file){
-          var fileContent = grunt.file.read(file);
-          var data = readJson(fileContent) || readIni(fileContent) || {};
-          processDirectives(data);
+          var data = readJson(file) || readIni(file) || {};
+          grunt.util._.extend(process.env, data);
         });
       }
     }
@@ -94,7 +109,6 @@ module.exports = function (grunt) {
 };
 
 
-
 function readJson(content) {
   try {
     return JSON.parse(content);
@@ -110,4 +124,3 @@ function readIni(content) {
     return;
   }
 }
-


### PR DESCRIPTION
Added support for reading yaml files.

I had to refactor a little bit as the `readIni` function doesn't complain when reading `yaml` file. Same thing for `grunt.file.readYAML` which doesn't throw an error when reading an `ini`.