### PR TITLE
Fix sample task aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Specify an ENV configuration as a task, e.g.
 
 ```
-grunt.registerTask('dev', 'env:dev lint server watch');
-grunt.registerTask('build', 'env:build lint other:build:tasks');
+grunt.registerTask('dev', ['env:dev', 'lint', 'server', 'watch']);
+grunt.registerTask('build', ['env:build', 'lint', 'other:build:tasks']);
 ```
 
 ## Getting Started


### PR DESCRIPTION
Fix syntax of sample task aliases, specifying tasks in an array.
