### PR TITLE
allow function for values

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,6 +52,12 @@ module.exports = function(grunt) {
 
           }
         }
+      },
+      testFunctions: {
+        DATA_FROM_FUNCTION: function() {
+          return process.env.DATA_FROM_FUNCTION || '123';
+        },
+        A_STRING: 'string'
       }
     },
     clean : {
@@ -84,6 +90,13 @@ module.exports = function(grunt) {
     assert.equal(process.env.localOption, 'baz', 'localOption should be set');
     delete process.env.globalOption;
     delete process.env.localOption;
+  });
+
+  grunt.registerTask('testFunctions', function(){
+    assert.equal(process.env.DATA_FROM_FUNCTION, '123', 'should set from function');
+    assert.equal(process.env.A_STRING, 'string', 'should set from string');
+    delete process.env.DATA_FROM_FUNCTION;
+    delete process.env.A_STRING;
   });
 
   grunt.registerTask('testDirectives', function(){
@@ -134,6 +147,8 @@ module.exports = function(grunt) {
     'testDotEnv',
     'env:testDirectives',
     'testDirectives',
+    'env:testFunctions',
+    'testFunctions',
     'clean'
   ]);
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ grunt.loadNpmTasks('grunt-env');
           'delimiter': ':'
         }
       }
+    },
+    functions: {
+      BY_FUNCTION: function() {
+        var value = '123;
+        grunt.log.writeln('setting BY_FUNCTION to ' + value);
+        return value;
+      }
     }
   }
 ```
@@ -107,7 +114,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 ## Release History
 
 - 0.4.0 Removed automatic parse, added ability to add ini or json style `src` files
-- 0.3.0 Automatically parses .env files now 
+- 0.3.0 Automatically parses .env files now
 - 0.2.1 fixed npm install
 - 0.2.0 grunt 0.4.0 support, simplified
 - 0.1.0 Initial release

--- a/tasks/env.js
+++ b/tasks/env.js
@@ -47,7 +47,7 @@ module.exports = function (grunt) {
         _.forEach(optionData, fn);
       } else {
         var data = {};
-        data[option] = optionData;
+        data[option] = typeof optionData === 'function' ? optionData() : optionData;
         _.extend(process.env, data);
       }
     });


### PR DESCRIPTION
This PR allows you to specify values for grunt-env keys as a function, using the returned value as the value for assignment. I have updated the README.md and the tests (all passing) to reflect this basic addition of functionality. My own practical use case was adding logging/validation to environment variables to be added, for example like this:

``` js
grunt.initConfig({
  env: {
    tester: {
      MY_VALUE: function() {
        grunt.log.writeln('Setting MY_VALUE to "123"');
        return '123';
      }
    }
  }
});
```
