### PR TITLE
Require utils via relative path

### DIFF
--- a/tasks/env.js
+++ b/tasks/env.js
@@ -10,7 +10,7 @@
 
 var _ = require('lodash');
 var path = require('path');
-var utils = require(process.cwd() + '/lib/utils');
+var utils = require('../lib/utils');
 
 module.exports = function(grunt) {
   var parse = function(file) {


### PR DESCRIPTION
"A module prefixed with './' is relative to the file calling require(). That is, circle.js must be in the same directory as foo.js for require('./circle') to find it."

There's no need to call process.cwd().  Additionally, this completely broke my usage of grunt-env with io.js; where process.cwd() resolved to the directory in which grunt had been run.  I did not investigate whether the same behavior exists on any of Joyent's releases of node.