### PR TITLE
Fix Cannot find module "lib/utils" exception

### DIFF
--- a/tasks/env.js
+++ b/tasks/env.js
@@ -10,7 +10,7 @@
 
 var _ = require('lodash');
 var path = require('path');
-var utils = require(process.cwd() + '/lib/utils');
+var utils = require('../lib/utils');
 
 module.exports = function(grunt) {
   var parse = function(file) {


### PR DESCRIPTION
This exception happened when I was using this plugin in my Yeoman project