### PR TITLE
Avoid setting undefined options since

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,10 @@ module.exports = function(grunt) {
         globalOption: 'foo'
       },
       testData: {
+        UNDEFINED_OPTION: function() {
+          // logic here might return undefined or not, but for testing we do
+          return undefined;
+        },
         TEST: 'test',
         data: 'bar'
       },
@@ -97,6 +101,12 @@ module.exports = function(grunt) {
     assert.equal(process.env.data, 'bar', 'data should be set');
     delete process.env.globalOption;
     delete process.env.data;
+
+    assert.equal(
+      process.env.hasOwnProperty('undefinedOption'),
+      false,
+      'undefinedOption should not be set on process.env'
+    );
   });
 
   grunt.registerTask('testOptions', function() {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "grunt": "~0.4.5",
+    "grunt-cli": "~1.2.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-jshint": "~0.11.0",
     "grunt-jscs": "^1.5.0"

--- a/tasks/env.js
+++ b/tasks/env.js
@@ -65,7 +65,10 @@ module.exports = function(grunt) {
       } else {
         var data = {};
         data[option] = typeof optionData === 'function' ? optionData() : optionData;
-        _.extend(process.env, data);
+
+        if (typeof data[option] !== undefined) {
+          _.extend(process.env, data);
+        }
       }
     });
   }


### PR DESCRIPTION
Ran into this bug in my own code. Basically I have two variations of a grunt tasl. One simulates a local environment, the other a DEV environment. In DEV and beyond an env var will be set, but in local it will not be set since it is generated by a platform I deploy my code on. This means I have this:

```js
env: {
      options: {},
      local: {
        NOT_DEFINED_LOCALLY: function () {
          return grunt.config('isLocal') ? undefined : 'set';
        }
     }
}
```

The issue arises here when `undefined` is returned. Doing `process.env.DEFINED_BASED_ON_ENV = undefined`, works, but when we get it later it's a String like `"undefined"` since node.js seems to change it when being set! For example this check would pass:

```js
// We're running locally so this should be undefined!
if (process.env.NOT_DEFINED_LOCALLY) {
  // Oops, we're in here since process.env.NOT_DEFINED_LOCALLY
  // was actually the String "undefined" and not just the undefined type
}
```

I made this PR since it works around this issue by allowing us to circumvent setting vars in certain configurations. We could have two options, e.g `env.local` and `env.dev`, but would be nice to avoid this pitfall.